### PR TITLE
feat: 50mb LRU for all stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   "dependencies": {
     "@ipld/block": "^4.0.0",
     "@ipld/fbl": "0.0.2",
-    "bent": "^7.1.2",
+    "bent": "^7.3.0",
     "charwise": "^3.0.1",
-    "datastore-car": "ipld/js-datastore-car#drop-eth",
+    "datastore-car": "^1.1.4",
     "encoding-down": "^6.3.0",
     "iamap": "^0.7.0",
     "ipld-schema-validation": "0.3.4",
     "level-js": "^5.0.2",
-    "levelup": "^4.3.2",
+    "levelup": "^4.4.0",
     "lru-cache": "^5.1.1",
     "murmurhash3js-revisited": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ipld-schema-validation": "0.3.4",
     "level-js": "^5.0.2",
     "levelup": "^4.3.2",
+    "lru-cache": "^5.1.1",
     "murmurhash3js-revisited": "^3.0.0"
   },
   "devDependencies": {

--- a/src/store/https.js
+++ b/src/store/https.js
@@ -1,8 +1,10 @@
 const bent = require('bent')
+const LRUStore = require('./lru')
 
 module.exports = Block => {
-  class HttpsStore {
-    constructor (baseurl) {
+  class HttpsStore extends LRUStore {
+    constructor (baseurl, opts) {
+      super(opts)
       let url
       let params
       if (baseurl.includes('?')) {
@@ -28,18 +30,18 @@ module.exports = Block => {
       return u
     }
 
-    async get (cid) {
+    async _getBlock (cid) {
       const data = await this._getBuffer(this.mkurl(cid.toString('base32')))
       return Block.create(data, cid)
     }
 
-    async put (block) {
+    async _putBlock (block) {
       const cid = await block.cid()
       const url = this.mkurl(cid.toString('base32'))
       return this._put(url, block.encodeUnsafe())
     }
 
-    async has (cid) {
+    async _hasBlock (cid) {
       const resp = await this._head(this.mkurl(cid.toString('base32')))
       if (resp.statusCode === 200) return true
       else return false

--- a/src/store/kv.js
+++ b/src/store/kv.js
@@ -1,7 +1,8 @@
 const CID = require('cids')
+const LRUStore = require('./lru')
 
 module.exports = Block => {
-  class KVStore {
+  class KVStore extends LRUStore {
     async graph (cid, depth = 1024, missing = new Set(), incomplete = new Set(), skips = new Set()) {
       const key = cid.toString('base32')
 
@@ -67,7 +68,7 @@ module.exports = Block => {
       if (complete) await this._putKey([key, 'complete'])
     }
 
-    async put (block) {
+    async _putBlock (block) {
       const cid = await block.cid()
       if (await this.has(cid)) return
       const seen = await this._indexLinks(cid, block)
@@ -75,11 +76,11 @@ module.exports = Block => {
       await this._indexComplete(cid, seen)
     }
 
-    has (cid) {
+    _hasBlock (cid) {
       return this._hasKey([cid.toString('base32'), 'encode'])
     }
 
-    async get (cid) {
+    async _getBlock (cid) {
       const key = cid.toString('base32')
       const data = await this._getKey([key, 'encode'])
       return Block.create(data, cid)

--- a/src/store/lru.js
+++ b/src/store/lru.js
@@ -1,0 +1,40 @@
+const LRU = require('lru-cache')
+
+const defaultSize = 1024 * 1024 * 50
+const getLength = block => block.encodeUnsafe().length
+
+class LRUStore {
+  constructor (opts = {}) {
+    if (typeof opts.lru === 'undefined') opts.lru = true
+    if (opts.lru) {
+      this.lru = new LRU({ max: opts.lruSize || defaultSize, length: getLength })
+    }
+  }
+
+  async get (cid) {
+    if (!this.lru) return this._getBlock(cid)
+    const key = cid.toString('base32')
+    if (this.lru.has(key)) return this.lru.get(key)
+    const block = await this._getBlock(cid)
+    this.lru.set(key, block)
+    return block
+  }
+
+  async put (block) {
+    if (!this.lru) return this._putBlock(block)
+    const key = (await block.cid()).toString('base32')
+    if (this.lru.has(key)) return
+    const ret = await this._putBlock(block)
+    this.lru.set(key, block)
+    return ret
+  }
+
+  has (cid) {
+    if (!this.lru) return this._hasBlock(cid)
+    const key = cid.toString('base32')
+    if (this.lru.has(key)) return { length: this.lru.get(key).decodeUnsafe().length }
+    return this._hasBlock(cid)
+  }
+}
+
+module.exports = LRUStore

--- a/test/lib/storage.js
+++ b/test/lib/storage.js
@@ -12,7 +12,7 @@ const hello = () => b({ hello: 'world' })
 const missingBlock = Block.encoder({ test: Math.random() }, 'dag-cbor')
 
 const basics = async create => {
-  const store = await create()
+  const store = await create({ lru: false })
   const block = Block.encoder({ hello: 'world' }, 'dag-cbor')
   await store.put(block)
   assert.ok(await store.has(await block.cid()))


### PR DESCRIPTION
This speeds up all the store implementations.

There’s still more that could be cached, like the `from-link` indexes, but that can come later.