### PR TITLE
Fix for remote database in browser over http

### DIFF
--- a/src/stores/https.js
+++ b/src/stores/https.js
@@ -31,7 +31,8 @@ export default Block => {
     }
 
     async _getBlock (cid) {
-      const data = await this._getBuffer(this.mkurl(cid.toString('base32')))
+      const buf = await this._getBuffer(this.mkurl(cid.toString('base32')))
+      const data = buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf
       return Block.create(data, cid)
     }
 


### PR DESCRIPTION
The following code wouldn't work in a browser:

```
const db = await dagdb.open('http://localhost:8080/')
console.log(await db.get('hello'))
```

It fails with a "Extraneous CBOR data found beyond initial top-level
object" error in @ipld/dag-cbor

The cause appears to be that `bent` is returning an ArrayBuffer in
the browser, but `borc` can only handle Node.js Buffer objects or
TypeArray (eg. Uint8Array). I'm not sure where the best place is
to convert it, but this seems to work.