### PR TITLE
Expose module subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     },
     "./server": {
       "import": "./src/http/nodejs.js"
+    },
+    "./": {
+      "import": "./esm/src/"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "import": "./src/http/nodejs.js"
     },
     "./": {
-      "import": "./esm/src/"
+      "import": "./src/"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #21

Note that if this option is too liberal with what it exposes, an alternative would be to specify specific subpaths:

```
package.json
...
"./database": {
  "import": "./src/database.js"
},
"./stores/": {
  "import": "./src/stores/"
},
"./updaters/": {
  "import": "./src/updaters/"
}
...
```

With this tiny change, one can now do things like:

```
import createHandler from "dagdb/server";
import kv from "dagdb/kv.js";
import LRUStore from "dagdb/stores/lru.js";
```

Note that for specific subpaths, a file extension is required, whereas the other exports (see server) can be used without extension.