### PR TITLE
Expose registration API on database

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -50,6 +50,10 @@ export default (Block) => {
       this.Block = Block
     }
 
+    register(type, fn) {
+      return kv.register(type, fn)
+    }
+
     get _dagdb () {
       return { v1: 'database' }
     }

--- a/src/database.js
+++ b/src/database.js
@@ -50,7 +50,7 @@ export default (Block) => {
       this.Block = Block
     }
 
-    register(type, fn) {
+    register (type, fn) {
       return kv.register(type, fn)
     }
 

--- a/src/values.js
+++ b/src/values.js
@@ -60,7 +60,6 @@ export default (Block) => {
     }
     if (value && typeof value === 'object') {
       if (value._dagdb) {
-        validate(value, 'DagDB')
         const type = Object.keys(value._dagdb.v1)[0]
         return types[type](value._dagdb.v1[type], store, updater)
       } else if (Array.isArray(value)) {

--- a/src/values.js
+++ b/src/values.js
@@ -1,4 +1,4 @@
-import { readonly, isCID, validate } from './utils.js'
+import { readonly, isCID } from './utils.js'
 import createFBL from '@ipld/fbl/bare'
 
 const types = {}


### PR DESCRIPTION
Fixes #23 

This PR exposes the custom type registration API on the top-level database. This is a powerful feature that is already used internally to allow embedding of custom types and classes, and now it can be used to support arbitrary custom types.

The API is pretty simple, it requires the caller to specify a `type` string, and an initialization function that takes two arguments, namely the `root` CID of the embedded custom type, and the underlying `store`. For example:

```js
const initCustomType = async (root, store) => {
  return new CustomType(await store.get(root))
}
```

Additionally, the custom type/object must support the following interface:

```ts
interface Encoder {
  _dagdb: { v1: string }
  encode(): AsyncGenerator<Block | CID>
}
```

From the internal docs: 
> Encoders, both here and in special types, are async generators that yield as many blocks as they like as long as the very last thing they yield is NOT a Block. This is so that the final root of each each node can be embedded in a parent. This contract MUST be adhered to by all special types. Additionally, the `_dagdb` property specifies the type name for v1 of the interface (leaving room for future interface changes), and is used to lookup the in memory custom type mapping.

To register the custom type, one simple calls register on the database:

```js
import dagdb from "dagdb";
let db = await dagdb.create("inmem");

db.register("custom", initCustomType);

const value = new CustomType(...args);
await db.set("key", value);
db = await db.update();

const custom = await local.get("key");
custom.method();
```