### PR TITLE
Remote testing nits

### DIFF
--- a/src/kv.js
+++ b/src/kv.js
@@ -377,7 +377,7 @@ const create = (Block) => {
         continue
       }
       // there's a conflict, pass it to the resolver
-      ops.set(key, resolver(oldOps, newOps, get))
+      ops.set(key, await resolver(oldOps, newOps, get))
     }
     return ops
   }

--- a/src/remotes.js
+++ b/src/remotes.js
@@ -62,7 +62,7 @@ export default (Block, stores, toBlock, updaters, CID) => {
       }
     }
 
-    async pull () {
+    async pull (resolver) {
       const info = await this.info
       if (info.source.type === 'local') {
         throw new Error('Local remotes must use pullDatabase directly')
@@ -75,13 +75,12 @@ export default (Block, stores, toBlock, updaters, CID) => {
           return root // no changes since last merge
         }
       }
-      return this.pullDatabase(database, info.strategy)
+      return this.pullDatabase(database, resolver)
     }
 
-    async pullDatabase (database, strategy) {
-      if (!strategy) {
-        strategy = (await this.info).strategy
-      }
+    async pullDatabase (database, resolver) {
+      const info = await this.info
+      const strategy = info.strategy
       const known = []
       if (this.rootDecode.head) {
         known.push(this.rootDecode.head)
@@ -89,9 +88,9 @@ export default (Block, stores, toBlock, updaters, CID) => {
       }
       let cids
       if (strategy.full) {
-        cids = await this.fullMerge(database, known, strategy.resolver)
+        cids = await this.fullMerge(database, known, resolver)
       } else if (strategy.keyed) {
-        cids = await this.keyedMerge(database, strategy.keyed, known, strategy.resolver)
+        cids = await this.keyedMerge(database, strategy.keyed, known, resolver)
       } /* c8 ignore next */ else {
         /* c8 ignore next */
         throw new Error(`Unknown strategy '${JSON.stringify(strategy)}'`)

--- a/src/remotes.js
+++ b/src/remotes.js
@@ -205,6 +205,10 @@ export default (Block, stores, toBlock, updaters, CID) => {
       await Promise.all(promises)
       return last.cid()
     }
+
+    register (name, fn) {
+      exports.register(name, fn)
+    }
   }
 
   const registry = { }

--- a/src/remotes.js
+++ b/src/remotes.js
@@ -173,11 +173,11 @@ export default (Block, stores, toBlock, updaters, CID) => {
       return this._get(name, Remote, 'Remote')
     }
 
-    async pull (name, remote) {
+    async pull (name, remote, resolver) {
       if (!remote) {
         remote = await this.get(name)
       }
-      await remote.pull()
+      await remote.pull(resolver)
       this.pending.set(name, remote)
     }
 


### PR DESCRIPTION
Tiny nit PR.

- [x] Ensures that we are always awaiting any potentially async resolver functions.
- [x] Exposes the remote register api on the remotes class.
- [x] Exposes a resolver argument on remote to support fine-grained resolving of conflicts.