### PR TITLE
Prevent recursion past null prev transaction

### DIFF
--- a/src/kv.js
+++ b/src/kv.js
@@ -417,6 +417,7 @@ const create = (Block) => {
       let { head, prev, ops } = decoded['kv-v1']
       if (head.equals(common)) return _ops
       ops = ops.map(op => get(op))
+      if (!prev) return [...ops, ..._ops]
       return since(await get(prev), [...ops, ..._ops])
     }
 


### PR DESCRIPTION
This tiny PR prevents the case where one replica is pulling from a remote, and the "search" for ops that have occurred since the replicas were last "in sync" ends up all the way back to its "empty" state. In other words, this catches the situation where replicas have no common point in their histories, beyond their empty state. Note that it _might_ be ok to throw in this case, but it is probably safe to _not throw_ here because we've already passed the common root check. Because of this, we can go all the way back to `prev == null`, and at that point assume we are just past our empty/initial state, and return the ops we've accumulated up to now.

TODO: Tests